### PR TITLE
fix(tools): Bug when dist/system dir doesn't exist

### DIFF
--- a/src/dev.js
+++ b/src/dev.js
@@ -56,7 +56,9 @@ module.exports = {
           dependencyPath + '/' + name.substring(0, name.indexOf('.js')) + '/system'
         ]; 
       }).forEach(function(value){
-        copyDir(value[0], value[1]);
+        if (fs.existsSync(value[0])) {
+          copyDir(value[0], value[1]);
+        }
       });
   },
   buildDevEnv: function () {


### PR DESCRIPTION
This should resolve issue with html-template-binding not having a system folder.
