### PR TITLE
feat(chrome-extension): Add chrome extension for debugging context

### DIFF
--- a/context-debugger/devtools.html
+++ b/context-debugger/devtools.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<script src="devtools.js"></script>
+</body>
+</html>

--- a/context-debugger/devtools.js
+++ b/context-debugger/devtools.js
@@ -1,0 +1,50 @@
+// The function below is executed in the context of the inspected page.
+var page_getProperties = function() {
+  var data = window.jQuery && $0 ? jQuery.data($0) : {};
+  // The current selected node
+  var selectedElement = $0;
+  if (selectedElement.parentNode){
+    var parent = selectedElement.parentNode;
+    var props = [];
+    if (parent && parent.childNodes.length > 0){
+      NodeList.prototype.forEach = Array.prototype.forEach
+      parent.childNodes.forEach(function (node){
+        if (node.classList) {
+          var validAureliaTarget = node.classList.contains('au-target');
+          if (validAureliaTarget && node.primaryBehavior){
+            var target = node.primaryBehavior.executionContext;
+            for(var property in target.__observers__) {
+              var propertyName = target.__observers__[property].propertyName;
+              var currentValue = target.__observers__[property].currentValue;
+              var getType = {};
+              var isFunction = (property && getType.toString.call(property) === '[object Function]');
+              if (!isFunction) {
+                props.push({'name': propertyName, 'value': currentValue});
+              }
+            }
+          }
+          // TODO: Go up the chain and continue looking instead of just the direct parent
+        }
+      });
+    }
+    if (props){
+      var copy = { __proto__: null };
+      props.forEach(function(prop) {
+        copy[prop.name] = prop.value;
+      });
+      return copy;
+    }
+  }
+  return false;
+}
+
+chrome.devtools.panels.elements.createSidebarPane(
+    "Aurelia Properties",
+    function(sidebar) {
+  function updateElementProperties() {
+    sidebar.setExpression("(" + page_getProperties.toString() + ")()");
+  }
+  updateElementProperties();
+  chrome.devtools.panels.elements.onSelectionChanged.addListener(
+      updateElementProperties);
+});

--- a/context-debugger/manifest.json
+++ b/context-debugger/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "Aurelia Context",
+  "version": "1.1",
+  "description": "Extends the Developer Tools, adding a sidebar that displays the Aurelia observer data associated with the selected DOM element.",
+  "devtools_page": "devtools.html",
+  "manifest_version": 2
+}


### PR DESCRIPTION
Chrome extension to debug the context of the currently selected DOM node.
To use it, simply clone the repo and follow these instructions -
http://superuser.com/questions/247651/how-does-one-install-an-extension-for-chrome-browser-from-the-local-file-system

Currently it only observes the parent node for `primaryBehavior` and looks at the `__observers__` property so it is only very useful on `compose` element and such so looking for some feedback for now.
