### PR TITLE
chore(dev): grab amd modules from own dependencies

### DIFF
--- a/src/dev.js
+++ b/src/dev.js
@@ -52,7 +52,7 @@ module.exports = {
       .filter(function(name){ return name.endsWith('.js'); })
       .map(function(name) {
         return [
-          '../' + name.substring(0, name.indexOf('@')) + '/dist/system',
+          '../' + name.substring(0, name.indexOf('@')) + '/dist/amd',
           dependencyPath + '/' + name.substring(0, name.indexOf('.js'))
         ];
       }).forEach(function(value){


### PR DESCRIPTION
Since module format is switched to amd across the repos these should grabed when updating own dependencies
