### PR TITLE
feat(build): add helper for sorting files based on imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,5 +16,9 @@
   "repository": {
     "type": "git",
     "url": "http://github.com/aurelia/tools"
+  },
+  "dependencies": {
+    "breeze-dag": "^0.1.0",
+    "through2": "^2.0.0"
   }
 }

--- a/src/build.js
+++ b/src/build.js
@@ -1,6 +1,52 @@
-var relativeImports = /import\s*{[a-zA-Z\,\s]+}\s*from\s*'\.\/[a-zA-Z\-]+';\s*/g;
+var path = require('path');
+var dag = require('breeze-dag');
+var through2 = require('through2');
+
+var relativeImports = /import\s*{[a-zA-Z\,\s]+}\s*from\s*'(\.[^\s']+)';\s*/g;
 var nonRelativeImports = /import\s*{?[a-zA-Z\*\,\s]+}?\s*from\s*'[a-zA-Z\-]+';\s*/g;
 var importGrouper = /import\s*{([a-zA-Z\,\s]+)}\s*from\s*'([a-zA-Z\-]+)'\s*;\s*/;
+
+exports.sortFiles = function sortFiles() {
+  var edges = [];
+  var files = {};
+
+  function getImports(file) {
+    var contents = file.contents;
+    var deps = [];
+    var match;
+    while (match = relativeImports.exec(contents)) {
+      deps.push(path.relative(file.base, path.resolve(file.base, match[1] + '.js')));
+    }
+
+    return deps;
+  }
+
+  function bufferFile(file, enc, callback) {
+    var imports = getImports(file);
+    if (!imports.length) {
+      // include a null dependency so disconnected nodes will be included in the DAG traversal
+      imports = [null];
+    }
+
+    imports.forEach(function(dependency) {
+      edges.push([dependency, file.relative]);
+    });
+
+    files[file.relative] = file;
+    callback();
+  }
+
+  function endStream(callback) {
+    var self = this;
+
+    dag(edges, 1, function(filePath, next) {
+      self.push(files[filePath]);
+      next();
+    }, callback);
+  }
+
+  return through2.obj(bufferFile, endStream);
+};
 
 exports.extractImports = function(content, importsToAdd){
   var matchesToKeep = content.match(nonRelativeImports);

--- a/src/index.js
+++ b/src/index.js
@@ -7,5 +7,6 @@ module.exports = {
   updateOwnDependenciesFromLocalRepositories:dev.updateOwnDependenciesFromLocalRepositories,
   buildDevEnv:dev.buildDevEnv,
   extractImports:build.extractImports,
-  createImportBlock:build.createImportBlock
+  createImportBlock:build.createImportBlock,
+  sortFiles:build.sortFiles
 };


### PR DESCRIPTION
This change adds a sortFiles helper that sorts a stream of files according to their relative import statements. The resulting list is safe for synchronous loading or concatenation. Circular dependencies are not supported. Use:

``` js
gulp.src('**/*.js')
  .pipe(sortFiles())
  .pipe(concat('all.js'))
  .pipe(gulp.dest('dist'));
```
