### PR TITLE
Display properties of the Aurelia context that is the closest to the selected element

### DIFF
--- a/context-debugger/devtools.js
+++ b/context-debugger/devtools.js
@@ -1,46 +1,67 @@
 // The function below is executed in the context of the inspected page.
-var page_getProperties = function() {
-  var data = window.jQuery && $0 ? jQuery.data($0) : {};
-  // The current selected node
-  var selectedElement = $0;
-  if (selectedElement.parentNode){
-    var parent = selectedElement.parentNode;
-    var props = [];
-    if (parent && parent.childNodes.length > 0){
-      NodeList.prototype.forEach = Array.prototype.forEach
-      parent.childNodes.forEach(function (node){
-        if (node.au && node.au.controller){
-          var target = node.au.controller.viewModel;
-          for(var property in target.__observers__) {
-            var propertyName = target.__observers__[property].propertyName;
-            var currentValue = target.__observers__[property].currentValue;
-            var getType = {};
-            var isFunction = (property && getType.toString.call(property) === '[object Function]');
-            if (!isFunction) {
-              props.push({'name': propertyName, 'value': currentValue});
-            }
-          }
+var page_getProperties = function () {
+  try {
+    function addModelProperties(key, model, useLongName) {
+      for (var property in model.__observers__) {
+        var observer = model.__observers__[property];
+        var propertyName = observer.propertyName;
+        var currentValue = observer.getValue ? observer.getValue() : observer.currentValue;
+        var getType = {};
+        var isFunction = (property && getType.toString.call(property) === '[object Function]');
+        if (!isFunction && propertyName !== undefined) {
+          props.push({
+            'name': useLongName ? key + "." + propertyName : propertyName,
+            'value': currentValue
+          });
         }
-      });
+      }
     }
-    if (props){
-      var copy = { __proto__: null };
-      props.forEach(function(prop) {
+
+    var data = window.jQuery && $0 ? jQuery.data($0) : {};
+    var selectedNode = $0;
+    var aureliaNode = selectedNode;
+    // go up the structure until an element affected by aurelia is found
+    while (aureliaNode !== null && aureliaNode !== undefined && aureliaNode.au === undefined) {
+      aureliaNode = aureliaNode.parentNode;
+    }
+
+    if (!aureliaNode) {
+      return false;
+    }
+
+    var props = [];
+
+    Object.keys(aureliaNode.au).forEach(function (key) {
+      var model = aureliaNode.au[key].model || aureliaNode.au[key].viewModel; // compatibility with aurelia 0.17 and 0.18
+      if (model && key !== 'controller') {
+        var useLongName = aureliaNode.au['controller'] === undefined || $0 !== aureliaNode;
+        addModelProperties(key, model, useLongName);
+      }
+    });
+
+    if (props.length !== 0) {
+      var copy = {__proto__: null};
+      props.forEach(function (prop) {
         copy[prop.name] = prop.value;
       });
       return copy;
     }
+    return null;
   }
-  return false;
-}
+  catch (e) {
+    console.log('Aurelia Properties plug-in error:', e);
+  }
+};
 
 chrome.devtools.panels.elements.createSidebarPane(
-    "Aurelia Properties",
-    function(sidebar) {
-  function updateElementProperties() {
-    sidebar.setExpression("(" + page_getProperties.toString() + ")()");
-  }
-  updateElementProperties();
-  chrome.devtools.panels.elements.onSelectionChanged.addListener(
-      updateElementProperties);
-});
+  "Aurelia Properties",
+  function (sidebar) {
+    function updateElementProperties() {
+      sidebar.setExpression("(" + page_getProperties.toString() + ")()");
+    }
+
+    updateElementProperties();
+    chrome.devtools.panels.elements.onSelectionChanged.addListener(updateElementProperties);
+  });
+
+


### PR DESCRIPTION
Improvements:
- Upon selecting an element that does not have an aurelia _context_ (`element.au` is defined), the plug-in goes up the parent chain and shows properties of the first parent that has an aurelia _context_.
- Add support for all types of controllers. For instance, an element with a `route-href` attribute will not have `element.au.controller` it will have `element.au['route-href']`.
- Add error handling
- Prepend the property name with the controller key if the aurelia context is found on a parent element.
- Resolve values for OoPropertyObserver instances (instead of returning undefined)
