### PR TITLE
fix(tools): change .eslintrc rules for ESLint 2 compatibility

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -158,11 +158,10 @@
       "before": false,
       "after": true
     }],
-    "space-after-keywords": 2,       // http://eslint.org/docs/rules/space-after-keywords
+    "keyword-spacing": [2, {"before": false, "after": false, "overrides": { "if": { "after": true }, "else": { "after": true }, "for": { "after": true }, "while": { "after": true }, "do": { "after": true }, "switch": { "after": true }, "try": { "after": true }, "catch": { "after": true }, "finally": { "after": true }, "with": { "after": true }, "throw": { "after": true }, "return": { "after": true }, "case": { "after": true } } }], // http://eslint.org/docs/rules/keyword-spacing
     "space-before-blocks": 2,        // http://eslint.org/docs/rules/space-before-blocks
     "space-before-function-paren": [2, "never"], // http://eslint.org/docs/rules/space-before-function-paren
     "space-infix-ops": 2,            // http://eslint.org/docs/rules/space-infix-ops
-    "space-return-throw-case": 2,    // http://eslint.org/docs/rules/space-return-throw-case
     "spaced-comment": [0, "always",  { // http://eslint.org/docs/rules/spaced-comment
       "exceptions": ["*"],
       "markers": ["*"]


### PR DESCRIPTION
ESLint V2.0 removed rules "space-after-keywords" and "space-return-throw-case", it also added the rule "keyword-spacing" that improves upon the previous two separate rules.
This commit removes the aforementioned rules and configures "keyword-spacing" to behave in the exact same way.
The rule is configured to replicate the exact cases that "space-after-keywords" and "space-return-throw-case" covered, however it could be further simplified to cover all cases seen in
http://eslint.org/docs/rules/keyword-spacing

Breaking Changes: Compatibility with ESLint < V2.0
