### PR TITLE
feat(eslint): limit eslint cascading

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "parser": "babel-eslint",          // https://github.com/babel/babel-eslint
   "env": {                           // http://eslint.org/docs/user-guide/configuring.html#specifying-environments
     "browser": true,                 // browser global variables


### PR DESCRIPTION
http://eslint.org/docs/user-guide/configuring#configuration-cascading-and-hierarchy

For example if I have this structure:

``` text
projects
├── .eslintrc
└─┬ aurelia
  ├── animator-css
  ├── binding
  └── bootstrapper
```

 `projects/.eslintrc` will affect the Aurelia repos who are using `aurelia-tools/.eslintrc`. This PR fixes that.
