### PR TITLE
feat(build): more permissive import detection

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -2,9 +2,9 @@ var path = require('path');
 var dag = require('breeze-dag');
 var through2 = require('through2');
 
-var relativeImports = /import\s*{[a-zA-Z0-9_\,\s]+}\s*from\s*'(\.[^\s']+)';\s*/g;
-var nonRelativeImports = /import(\s*{?[a-zA-Z0-9_\*\,\s]+}?)?(\s*as\s*[a-zA-Z0-9]+)?(\s*from)?\s*'[a-zA-Z0-9\-]+';\s*/g;
-var importGrouper = /import\s*{([a-zA-Z0-9_\,\s]+)}\s*from\s*'([a-zA-Z0-9\-]+)'\s*;\s*/;
+var relativeImports = /import\s*{[a-zA-Z0-9_\$\,\s]+}\s*from\s*'(\.[^\s']+)';\s*/g;
+var nonRelativeImports = /import(\s*{?[a-zA-Z0-9_\$\*\,\s]+}?)?(\s*as\s*[a-zA-Z0-9_\$]+)?(\s*from)?\s*'[a-zA-Z0-9_\-\/]+';\s*/g;
+var importGrouper = /import\s*{([a-zA-Z0-9_\$\,\s]+)}\s*from\s*'([a-zA-Z0-9_\-\/]+)'\s*;\s*/;
 
 exports.sortFiles = function sortFiles() {
   var edges = [];


### PR DESCRIPTION
default github installations eg
`jspm install spoonx/aurelia-api`
are imported with
`import {xyz} from 'spoonx/aurelia-api';`
proposed change detects the `/` and thus correctly detects those imports
