### PR TITLE
chore(tools): change .eslintrc to be compatible with eslint 2.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "parser": "babel-eslint",          // https://github.com/babel/babel-eslint
   "env": {                           // http://eslint.org/docs/user-guide/configuring.html#specifying-environments
     "browser": true,                 // browser global variables

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,4 @@
 {
-  "root": true,
   "parser": "babel-eslint",          // https://github.com/babel/babel-eslint
   "env": {                           // http://eslint.org/docs/user-guide/configuring.html#specifying-environments
     "browser": true,                 // browser global variables
@@ -159,11 +158,10 @@
       "before": false,
       "after": true
     }],
-    "space-after-keywords": 2,       // http://eslint.org/docs/rules/space-after-keywords
+    "keyword-spacing": [2, {"before": true, "after": true}], //http://eslint.org/docs/rules/keyword-spacing
     "space-before-blocks": 2,        // http://eslint.org/docs/rules/space-before-blocks
     "space-before-function-paren": [2, "never"], // http://eslint.org/docs/rules/space-before-function-paren
     "space-infix-ops": 2,            // http://eslint.org/docs/rules/space-infix-ops
-    "space-return-throw-case": 2,    // http://eslint.org/docs/rules/space-return-throw-case
     "spaced-comment": [0, "always",  { // http://eslint.org/docs/rules/spaced-comment
       "exceptions": ["*"],
       "markers": ["*"]


### PR DESCRIPTION
ESLint 2.0 removed the rules "space-after-keywords" and "space-return-throw-case" and replaced them with "keyword-spacing", said rule controls spacing behaviour for spaces before and after keywords, .eslintrc has been changed to reflect that and now spaces are necessary before and after each keyword

BREAKING CHANGES: compatibility with ESLint < 2.0

(had to create a new PR, I accidentally broke the repo on the previous one)
