### PR TITLE
chore(eslint): disable consistent-return rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -75,7 +75,7 @@
 /**
  * Best practices
  */
-    "consistent-return": 2,          // http://eslint.org/docs/rules/consistent-return
+    "consistent-return": 0,          // http://eslint.org/docs/rules/consistent-return
     "curly": [2, "multi-line"],      // http://eslint.org/docs/rules/curly
     "default-case": 2,               // http://eslint.org/docs/rules/default-case
     "dot-notation": [2, {            // http://eslint.org/docs/rules/dot-notation


### PR DESCRIPTION
This rule causes lint failures when using arrow functions.
