### PR TITLE
chore: fix npm warning on peer dependency of babel-eslint@^7.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "through2": "^2.0.0"
   },
   "peerDependencies": {
-    "babel-eslint": "^7.2.3",
+    "babel-eslint": "^7.0.0 || ^8.0.0",
     "eslint": "^4.0.0"
   }
 }


### PR DESCRIPTION
Project boostrapped by aurelia-cli has babel-eslint@^8.2.2 installed.