### PR TITLE
chore: support legacy decorator in babel v7

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,6 +9,7 @@
     "ecmaVersion": 6,
     "sourceType": "module",
     "ecmaFeatures": {
+      "legacyDecorators": true,
       "impliedStrict": true,
       "arrowFunctions": true,
       "blockBindings": true,


### PR DESCRIPTION
reference babel-eslint release note https://github.com/babel/babel-eslint/releases/tag/v9.0.0